### PR TITLE
Improve project management UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ export const metadata = {
 };
 
 import { ReactNode } from 'react';
+import { ProjectsProvider } from '../components/ProjectsProvider';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -25,7 +26,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/ressources">Ressources</Link>
           </nav>
         </aside>
-        <main className="flex-1">{children}</main>
+        <ProjectsProvider>
+          <main className="flex-1">{children}</main>
+        </ProjectsProvider>
       </body>
     </html>
   );

--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -1,6 +1,8 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { useEffect } from 'react';
+import { useProjects } from '../../components/ProjectsProvider';
 
 interface FormValues {
   name: string;
@@ -15,87 +17,144 @@ interface FormValues {
 
 export default function NewProjectPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { projects, addProject, updateProject } = useProjects();
+  const editId = searchParams.get('id');
+  const project = editId ? projects.find((p) => p.id === Number(editId)) : undefined;
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({ defaultValues: { status: 'Conception', type: 'Photo' } });
+    reset,
+  } = useForm<FormValues>({
+    defaultValues: project
+      ? {
+          name: project.name,
+          client: project.client,
+          description: project.description,
+          startDate: project.startDate,
+          dueDate: project.endDate,
+          status: project.status,
+          type: 'Photo',
+          budget: project.budget,
+        }
+      : { status: 'Conception', type: 'Photo' },
+  });
+
+  useEffect(() => {
+    if (project) {
+      reset({
+        name: project.name,
+        client: project.client,
+        description: project.description,
+        startDate: project.startDate,
+        dueDate: project.endDate,
+        status: project.status,
+        type: 'Photo',
+        budget: project.budget,
+      });
+    }
+  }, [project, reset]);
 
   const onSubmit = (data: FormValues) => {
-    console.log(data);
-    alert('Projet créé avec succès');
+    const payload = {
+      name: data.name,
+      client: data.client,
+      description: data.description,
+      startDate: data.startDate,
+      endDate: data.dueDate,
+      status: data.status as any,
+      budget: data.budget,
+    };
+    if (editId) {
+      updateProject(Number(editId), payload);
+    } else {
+      addProject(payload);
+    }
     router.push('/projects');
   };
 
   return (
-    <div>
-      <h1 className="mb-6 text-3xl font-bold">Nouveau projet</h1>
-      <form onSubmit={handleSubmit(onSubmit)} className="max-w-xl space-y-4">
-        <div>
-          <label className="mb-1 block font-semibold">Nom du projet</label>
-          <input
-            {...register('name', { required: true })}
-            placeholder="Mariage..."
-            className="w-full rounded border px-3 py-2"
-          />
-          {errors.name && <p className="text-sm text-red-600">Ce champ est requis</p>}
+    <div className="p-4">
+      <h1 className="mb-6 text-3xl font-bold">{editId ? 'Modifier le projet' : 'Nouveau projet'}</h1>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="mx-auto max-w-2xl space-y-6 rounded border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Informations générales</h2>
+          <div>
+            <label className="mb-1 block font-semibold">Nom du projet</label>
+            <input
+              {...register('name', { required: true })}
+              placeholder="Mariage..."
+              className="w-full rounded border px-3 py-2"
+            />
+            {errors.name && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block font-semibold">Client</label>
+            <select {...register('client', { required: true })} className="w-full rounded border px-3 py-2">
+              <option value="">-- Sélectionner --</option>
+              <option value="Client A">Client A</option>
+              <option value="Client B">Client B</option>
+            </select>
+            {errors.client && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block font-semibold">Description</label>
+            <textarea
+              {...register('description')}
+              placeholder="Détails du projet"
+              className="w-full rounded border px-3 py-2"
+            />
+          </div>
         </div>
-        <div>
-          <label className="mb-1 block font-semibold">Client</label>
-          <select {...register('client', { required: true })} className="w-full rounded border px-3 py-2">
-            <option value="">-- Sélectionner --</option>
-            <option value="Client A">Client A</option>
-            <option value="Client B">Client B</option>
-          </select>
-          {errors.client && <p className="text-sm text-red-600">Ce champ est requis</p>}
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Dates</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block font-semibold">Date de début</label>
+              <input type="date" {...register('startDate')} className="w-full rounded border px-3 py-2" />
+            </div>
+            <div>
+              <label className="mb-1 block font-semibold">Date de fin</label>
+              <input type="date" {...register('dueDate')} className="w-full rounded border px-3 py-2" />
+            </div>
+          </div>
         </div>
-        <div>
-          <label className="mb-1 block font-semibold">Description</label>
-          <textarea
-            {...register('description')}
-            placeholder="Détails du projet"
-            className="w-full rounded border px-3 py-2"
-          />
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Budget</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block font-semibold">Statut</label>
+              <select {...register('status')} className="w-full rounded border px-3 py-2">
+                {['Conception', 'Tournage', 'Montage', 'Prêt', 'Envoyé', 'Terminé'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block font-semibold">Budget (€)</label>
+              <input type="number" {...register('budget', { valueAsNumber: true })} className="w-full rounded border px-3 py-2" />
+            </div>
+          </div>
         </div>
-        <div>
-          <label className="mb-1 block font-semibold">Date de début</label>
-          <input type="date" {...register('startDate')} className="w-full rounded border px-3 py-2" />
-        </div>
-        <div>
-          <label className="mb-1 block font-semibold">Date prévue</label>
-          <input type="date" {...register('dueDate')} className="w-full rounded border px-3 py-2" />
-        </div>
-        <div>
-          <label className="mb-1 block font-semibold">Statut</label>
-          <select {...register('status')} className="w-full rounded border px-3 py-2">
-            {['Conception', 'Tournage', 'Montage', 'Prêt', 'Envoyé', 'Terminé'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="mb-1 block font-semibold">Type de projet</label>
-          <select {...register('type')} className="w-full rounded border px-3 py-2">
-            <option value="Photo">Photo</option>
-            <option value="Video">Vidéo</option>
-          </select>
-        </div>
-        <div>
-          <label className="mb-1 block font-semibold">Budget (€)</label>
-          <input type="number" {...register('budget', { valueAsNumber: true })} className="w-full rounded border px-3 py-2" />
-        </div>
-        <div className="mt-6 flex space-x-2">
+
+        <div className="flex justify-end space-x-2">
           <button type="submit" className="rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600">
-            ✅ Créer le projet
+            {editId ? 'Enregistrer' : 'Créer le projet'}
           </button>
           <button
             type="button"
             onClick={() => router.push('/projects')}
             className="rounded bg-red-500 px-4 py-2 text-white hover:bg-red-600"
           >
-            ❌ Annuler
+            Annuler
           </button>
         </div>
       </form>

--- a/components/DeleteModal.tsx
+++ b/components/DeleteModal.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { ReactNode } from 'react';
+
+interface DeleteModalProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  children?: ReactNode;
+}
+
+export default function DeleteModal({ isOpen, onCancel, onConfirm, children }: DeleteModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/50">
+      <div className="w-80 rounded bg-white p-6 shadow-lg dark:bg-gray-800">
+        <p className="mb-4 text-center text-sm text-gray-700 dark:text-gray-100">
+          {children}
+        </p>
+        <div className="flex justify-end space-x-2">
+          <button
+            onClick={onCancel}
+            className="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={onConfirm}
+            className="rounded bg-red-500 px-3 py-1 text-sm text-white hover:bg-red-600"
+          >
+            Confirmer la suppression
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { FaCamera } from 'react-icons/fa';
+import { Project, Status } from './ProjectsProvider';
+
+interface ProjectCardProps {
+  project: Project;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const statusColors: Record<Status, string> = {
+  Conception: 'bg-yellow-200 text-yellow-700',
+  Tournage: 'bg-blue-200 text-blue-700',
+  Montage: 'bg-purple-200 text-purple-700',
+  Prêt: 'bg-green-200 text-green-700',
+  Envoyé: 'bg-blue-500 text-white',
+  Terminé: 'bg-gray-500 text-white',
+};
+
+export default function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
+  return (
+    <div className="rounded-lg bg-gray-100 p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:bg-gray-800">
+      <div className="flex items-center space-x-2">
+        <FaCamera className="text-xl text-gray-500" />
+        <h2 className="text-lg font-semibold">{project.name}</h2>
+      </div>
+      <p className="text-sm text-gray-600">Client : {project.client}</p>
+      <p className="mt-2 text-sm text-gray-700">{project.description}</p>
+      <div className="mt-2 flex items-center justify-between text-sm">
+        <span className="flex items-center space-x-1 text-gray-600">
+          <span role="img" aria-label="date">
+            📅
+          </span>
+          <span>{project.startDate}</span>
+        </span>
+        <span className="flex items-center space-x-1 text-green-600">
+          <span role="img" aria-label="budget">
+            💶
+          </span>
+          <span>{project.budget}</span>
+        </span>
+      </div>
+      <span className={`mt-2 inline-block rounded px-2 py-1 text-xs font-semibold ${statusColors[project.status]}`}>{project.status}</span>
+      <div className="mt-4 flex space-x-2">
+        <button
+          onClick={onEdit}
+          className="flex items-center space-x-1 rounded border border-yellow-500 px-3 py-1 text-sm text-yellow-600 hover:bg-yellow-50 dark:border-yellow-400 dark:text-yellow-400"
+        >
+          <span>✏️</span>
+          <span>Modifier</span>
+        </button>
+        <button
+          onClick={onDelete}
+          className="flex items-center space-x-1 rounded border border-red-500 px-3 py-1 text-sm text-red-600 hover:bg-red-50 dark:border-red-400 dark:text-red-400"
+        >
+          <span>🗑️</span>
+          <span>Supprimer</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/ProjectsProvider.tsx
+++ b/components/ProjectsProvider.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export type Status =
+  | 'Conception'
+  | 'Tournage'
+  | 'Montage'
+  | 'Prêt'
+  | 'Envoyé'
+  | 'Terminé';
+
+export interface Project {
+  id: number;
+  name: string;
+  client: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  budget: number;
+  status: Status;
+}
+
+type ProjectsContextType = {
+  projects: Project[];
+  addProject: (project: Omit<Project, 'id'>) => void;
+  updateProject: (id: number, project: Omit<Project, 'id'>) => void;
+  deleteProject: (id: number) => void;
+};
+
+const ProjectsContext = createContext<ProjectsContextType | undefined>(undefined);
+
+const initialProjects: Project[] = [
+  {
+    id: 1,
+    name: 'Mariage Sarah & Tom',
+    client: 'Sarah Martin',
+    description: 'Couverture photo et vidéo du mariage',
+    startDate: '2024-06-10',
+    endDate: '2024-06-15',
+    budget: 1500,
+    status: 'Tournage',
+  },
+  {
+    id: 2,
+    name: "Clip promo Maison d'hôtes",
+    client: 'Le Beau Gîte',
+    description: "Réalisation d'une vidéo publicitaire",
+    startDate: '2024-05-01',
+    endDate: '2024-05-02',
+    budget: 2000,
+    status: 'Montage',
+  },
+  {
+    id: 3,
+    name: 'Shooting produits Printemps',
+    client: 'Mode & Chic',
+    description: 'Photos catalogue printemps',
+    startDate: '2024-04-20',
+    endDate: '2024-04-22',
+    budget: 800,
+    status: 'Conception',
+  },
+];
+
+export function ProjectsProvider({ children }: { children: ReactNode }) {
+  const [projects, setProjects] = useState<Project[]>(initialProjects);
+
+  const addProject = (project: Omit<Project, 'id'>) => {
+    const id = projects.length ? Math.max(...projects.map((p) => p.id)) + 1 : 1;
+    setProjects([...projects, { id, ...project }]);
+  };
+
+  const updateProject = (id: number, project: Omit<Project, 'id'>) => {
+    setProjects(projects.map((p) => (p.id === id ? { id, ...project } : p)));
+  };
+
+  const deleteProject = (id: number) => {
+    setProjects(projects.filter((p) => p.id !== id));
+  };
+
+  return (
+    <ProjectsContext.Provider value={{ projects, addProject, updateProject, deleteProject }}>
+      {children}
+    </ProjectsContext.Provider>
+  );
+}
+
+export function useProjects() {
+  const context = useContext(ProjectsContext);
+  if (!context) {
+    throw new Error('useProjects must be used within ProjectsProvider');
+  }
+  return context;
+}

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useEffect } from 'react';
+
+interface ToastProps {
+  message: string | null;
+  onClose: () => void;
+}
+
+export default function Toast({ message, onClose }: ToastProps) {
+  useEffect(() => {
+    if (!message) return;
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [message, onClose]);
+
+  if (!message) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-10 -translate-x-1/2 rounded bg-green-500 px-4 py-2 text-white shadow">
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add project context provider and wrap layout with it
- overhaul project list page with cards, edit/delete actions and toast
- enhance project form with sections and editing capability
- add reusable components for project card, delete modal and toast

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a62b522083298e018e78757072fd