### PR TITLE
Improve project pages with modal and extended forms

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/navigation';
 import ProjectCard from '../../components/ProjectCard';
 import DeleteModal from '../../components/DeleteModal';
 import Toast from '../../components/Toast';
-import { useProjects, Status } from '../../components/ProjectsProvider';
+import ProjectModal from '../../components/ProjectModal';
+import { useProjects, Status, Project } from '../../components/ProjectsProvider';
 
 const statusColors: Record<Status, string> = {
   Conception: 'bg-yellow-200 text-yellow-700',
@@ -25,6 +26,7 @@ export default function ProjectsPage() {
   const [sort, setSort] = useState<'startDate' | 'budget'>('startDate');
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [activeProject, setActiveProject] = useState<Project | null>(null);
 
   const handleEdit = (id: number) => {
     router.push(`/new-project?id=${id}`);
@@ -42,6 +44,12 @@ export default function ProjectsPage() {
     }
   };
 
+  const openProject = (project: Project) => {
+    setActiveProject(project);
+  };
+
+  const closeProject = () => setActiveProject(null);
+
   const filtered = projects
     .filter((p) => (filter === 'Tous' ? true : p.status === filter))
     .filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
@@ -53,8 +61,8 @@ export default function ProjectsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">Projets récents</h1>
+      <div className="mt-8 mb-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+        <h1 className="text-center text-4xl font-bold">Mes projets</h1>
         <Link
           href="/new-project"
           className="rounded bg-blue-500 px-4 py-2 font-semibold text-white hover:bg-blue-600"
@@ -81,7 +89,7 @@ export default function ProjectsPage() {
         </select>
       </div>
 
-      <div className="my-6 flex space-x-2 overflow-x-auto">
+      <div className="mt-4 mb-8 flex space-x-2 overflow-x-auto">
         {['Conception', 'Tournage', 'Montage', 'Prêt', 'Envoyé', 'Terminé'].map((s) => (
           <button
             key={s}
@@ -112,6 +120,7 @@ export default function ProjectsPage() {
             project={project}
             onEdit={() => handleEdit(project.id)}
             onDelete={() => handleDelete(project.id)}
+            onOpen={() => openProject(project)}
           />
         ))}
       </div>
@@ -122,6 +131,13 @@ export default function ProjectsPage() {
       >
         Voulez-vous vraiment supprimer ce projet ?
       </DeleteModal>
+      {activeProject && (
+        <ProjectModal
+          project={activeProject}
+          onClose={closeProject}
+          onEdit={() => handleEdit(activeProject.id)}
+        />
+      )}
       <Toast message={toast} onClose={() => setToast(null)} />
     </div>
   );

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -6,6 +6,7 @@ interface ProjectCardProps {
   project: Project;
   onEdit: () => void;
   onDelete: () => void;
+  onOpen: () => void;
 }
 
 const statusColors: Record<Status, string> = {
@@ -17,23 +18,26 @@ const statusColors: Record<Status, string> = {
   Terminé: 'bg-gray-500 text-white',
 };
 
-export default function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
+export default function ProjectCard({ project, onEdit, onDelete, onOpen }: ProjectCardProps) {
   return (
-    <div className="rounded-lg bg-gray-100 p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:bg-gray-800">
+    <div
+      onClick={onOpen}
+      className="cursor-pointer rounded-xl bg-gray-800 p-6 text-gray-100 shadow-md transition-transform hover:scale-105 hover:shadow-lg"
+    >
       <div className="flex items-center space-x-2">
-        <FaCamera className="text-xl text-gray-500" />
+        <FaCamera className="text-xl text-gray-400" />
         <h2 className="text-lg font-semibold">{project.name}</h2>
       </div>
-      <p className="text-sm text-gray-600">Client : {project.client}</p>
-      <p className="mt-2 text-sm text-gray-700">{project.description}</p>
+      <p className="text-sm text-gray-300">Client : {project.client}</p>
+      <p className="mt-2 text-sm text-gray-200">{project.description}</p>
       <div className="mt-2 flex items-center justify-between text-sm">
-        <span className="flex items-center space-x-1 text-gray-600">
+        <span className="flex items-center space-x-1 text-gray-300">
           <span role="img" aria-label="date">
             📅
           </span>
           <span>{project.startDate}</span>
         </span>
-        <span className="flex items-center space-x-1 text-green-600">
+        <span className="flex items-center space-x-1 text-green-400">
           <span role="img" aria-label="budget">
             💶
           </span>
@@ -43,14 +47,20 @@ export default function ProjectCard({ project, onEdit, onDelete }: ProjectCardPr
       <span className={`mt-2 inline-block rounded px-2 py-1 text-xs font-semibold ${statusColors[project.status]}`}>{project.status}</span>
       <div className="mt-4 flex space-x-2">
         <button
-          onClick={onEdit}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
           className="flex items-center space-x-1 rounded border border-yellow-500 px-3 py-1 text-sm text-yellow-600 hover:bg-yellow-50 dark:border-yellow-400 dark:text-yellow-400"
         >
           <span>✏️</span>
           <span>Modifier</span>
         </button>
         <button
-          onClick={onDelete}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
           className="flex items-center space-x-1 rounded border border-red-500 px-3 py-1 text-sm text-red-600 hover:bg-red-50 dark:border-red-400 dark:text-red-400"
         >
           <span>🗑️</span>

--- a/components/ProjectModal.tsx
+++ b/components/ProjectModal.tsx
@@ -1,0 +1,134 @@
+'use client';
+import { useState } from 'react';
+import { Project, Task, DocumentFile, useProjects, Status } from './ProjectsProvider';
+import DeleteModal from './DeleteModal';
+
+interface ProjectModalProps {
+  project: Project;
+  onClose: () => void;
+  onEdit: () => void;
+}
+
+const steps: Status[] = ['Conception', 'Tournage', 'Montage', 'Prêt', 'Envoyé', 'Terminé'];
+
+export default function ProjectModal({ project, onClose, onEdit }: ProjectModalProps) {
+  const { updateProject, deleteProject } = useProjects();
+  const [taskText, setTaskText] = useState('');
+  const [showDelete, setShowDelete] = useState(false);
+  const addTask = () => {
+    if (!taskText.trim()) return;
+    const newTask: Task = { id: Date.now(), text: taskText, completed: false };
+    updateProject(project.id, { ...project, tasks: [...project.tasks, newTask] });
+    setTaskText('');
+  };
+  const toggleTask = (id: number) => {
+    const tasks = project.tasks.map(t => t.id === id ? { ...t, completed: !t.completed } : t);
+    updateProject(project.id, { ...project, tasks });
+  };
+  const removeTask = (id: number) => {
+    const tasks = project.tasks.filter(t => t.id !== id);
+    updateProject(project.id, { ...project, tasks });
+  };
+  const saveNotes = (notes: string) => {
+    updateProject(project.id, { ...project, notes });
+  };
+  const addDocument = (file: File | null) => {
+    if (!file) return;
+    const doc: DocumentFile = { id: Date.now(), name: file.name, path: file.name };
+    updateProject(project.id, { ...project, documents: [...project.documents, doc] });
+  };
+  const removeDocument = (id: number) => {
+    const documents = project.documents.filter(d => d.id !== id);
+    updateProject(project.id, { ...project, documents });
+  };
+  const confirmDelete = () => {
+    deleteProject(project.id);
+    setShowDelete(false);
+    onClose();
+  };
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/60 overflow-auto">
+      <div className="m-4 w-full max-w-2xl space-y-6 rounded-lg bg-gray-900 p-6 text-gray-100 shadow-lg">
+        <div className="flex items-start justify-between">
+          <h2 className="text-2xl font-bold flex-1 text-center">{project.name}</h2>
+          <button onClick={onClose} className="ml-4 text-xl">❌</button>
+        </div>
+        <div className="space-y-4">
+          <div className="space-x-2 flex flex-wrap justify-center">
+            {steps.map((s) => (
+              <span
+                key={s}
+                className={`flex items-center space-x-1 text-sm ${
+                  steps.indexOf(s) <= steps.indexOf(project.status) ? 'text-green-400' : 'text-gray-500'
+                }`}
+              >
+                <span>{steps.indexOf(s) < steps.indexOf(project.status) ? '✔️' : steps.indexOf(s) === steps.indexOf(project.status) ? '⚪️' : '⚪️'}</span>
+                <span>{s}{s === project.status && ' (En cours)'}</span>
+              </span>
+            ))}
+          </div>
+
+          <div>
+            <h3 className="mb-2 font-semibold">Tâches</h3>
+            <div className="space-y-2">
+              {project.tasks.map((t) => (
+                <div key={t.id} className="flex items-center justify-between">
+                  <label className="flex items-center space-x-2">
+                    <input type="checkbox" checked={t.completed} onChange={() => toggleTask(t.id)} />
+                    <span className={t.completed ? 'line-through text-gray-400' : ''}>{t.text}</span>
+                  </label>
+                  <button onClick={() => removeTask(t.id)} className="text-red-400">🗑️</button>
+                </div>
+              ))}
+              <div className="flex space-x-2">
+                <input
+                  value={taskText}
+                  onChange={(e) => setTaskText(e.target.value)}
+                  className="flex-1 rounded border border-gray-700 bg-gray-800 px-2 py-1"
+                />
+                <button onClick={addTask} className="rounded bg-blue-600 px-3 text-white">➕</button>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="mb-2 font-semibold">Notes personnelles</h3>
+            <textarea
+              defaultValue={project.notes}
+              onBlur={(e) => saveNotes(e.target.value)}
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2"
+            />
+          </div>
+
+          <div>
+            <h3 className="mb-2 font-semibold">Documents liés</h3>
+            <ul className="space-y-1">
+              {project.documents.map((d) => (
+                <li key={d.id} className="flex items-center justify-between">
+                  <a href={d.path} className="text-blue-400 underline" target="_blank" rel="noreferrer">
+                    {d.name}
+                  </a>
+                  <button onClick={() => removeDocument(d.id)} className="text-red-400">🗑️</button>
+                </li>
+              ))}
+            </ul>
+            <input
+              type="file"
+              onChange={(e) => addDocument(e.target.files ? e.target.files[0] : null)}
+              className="mt-2"
+            />
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button onClick={onEdit} className="rounded bg-yellow-500 px-4 py-2 font-semibold text-black hover:bg-yellow-400 sm:w-auto w-full">✏️ Modifier</button>
+          <button onClick={() => setShowDelete(true)} className="rounded bg-red-500 px-4 py-2 font-semibold text-white hover:bg-red-600 sm:w-auto w-full">🗑️ Supprimer</button>
+        </div>
+      </div>
+      <DeleteModal
+        isOpen={showDelete}
+        onCancel={() => setShowDelete(false)}
+        onConfirm={confirmDelete}
+      >Voulez-vous vraiment supprimer ce projet ?</DeleteModal>
+    </div>
+  );
+}

--- a/components/ProjectsProvider.tsx
+++ b/components/ProjectsProvider.tsx
@@ -9,6 +9,18 @@ export type Status =
   | 'Envoyé'
   | 'Terminé';
 
+export interface Task {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+export interface DocumentFile {
+  id: number;
+  name: string;
+  path: string;
+}
+
 export interface Project {
   id: number;
   name: string;
@@ -18,6 +30,9 @@ export interface Project {
   endDate: string;
   budget: number;
   status: Status;
+  tasks: Task[];
+  notes: string;
+  documents: DocumentFile[];
 }
 
 type ProjectsContextType = {
@@ -39,6 +54,9 @@ const initialProjects: Project[] = [
     endDate: '2024-06-15',
     budget: 1500,
     status: 'Tournage',
+    tasks: [],
+    notes: '',
+    documents: [],
   },
   {
     id: 2,
@@ -49,6 +67,9 @@ const initialProjects: Project[] = [
     endDate: '2024-05-02',
     budget: 2000,
     status: 'Montage',
+    tasks: [],
+    notes: '',
+    documents: [],
   },
   {
     id: 3,
@@ -59,6 +80,9 @@ const initialProjects: Project[] = [
     endDate: '2024-04-22',
     budget: 800,
     status: 'Conception',
+    tasks: [],
+    notes: '',
+    documents: [],
   },
 ];
 


### PR DESCRIPTION
## Summary
- extend project model with tasks, notes and documents
- add detailed project modal with task management
- refine project cards with better hover and colors
- enhance new project form with tasks, notes, documents and manual client entry
- update projects page styling and integrate project modal

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b091a0bc832984932cbc8559e733