### PR TITLE
Add client management page

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,3 +1,86 @@
+'use client';
+import { useState } from 'react';
+import AddClientModal from '../../components/AddClientModal';
+import ClientCard from '../../components/ClientCard';
+import Toast from '../../components/Toast';
+import { initialClients, Client } from '../../lib/data/clients';
+import { Plus } from 'lucide-react';
+
+const filterTags = ['Tous', 'Prospect', 'Client', 'mariage', 'client-fidele', 'e-commerce', 'corporate', 'startup'];
+
 export default function ClientsPage() {
-  return <h1 className="text-2xl font-bold">Liste des clients</h1>;
+  const [clients, setClients] = useState<Client[]>(initialClients);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('Tous');
+  const [showModal, setShowModal] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const addClient = (client: Client) => {
+    setClients([...clients, client]);
+    setToast('Client ajouté avec succès');
+  };
+
+  const handleDelete = (id: string) => {
+    if (confirm('Supprimer client ?')) {
+      setClients(clients.filter(c => c.id !== id));
+    }
+  };
+
+  const filtered = clients.filter(c => {
+    const text = `${c.firstName} ${c.lastName} ${c.company ?? ''}`.toLowerCase();
+    const matchSearch = text.includes(search.toLowerCase());
+    const matchFilter = filter === 'Tous'
+      ? true
+      : filter === 'Client' || filter === 'Prospect'
+      ? c.status === filter
+      : c.tags.includes(filter);
+    return matchSearch && matchFilter;
+  });
+
+  return (
+    <div className="p-4">
+      <div className="mb-6 flex flex-col items-center justify-between gap-4 sm:flex-row">
+        <h1 className="text-center text-4xl font-bold">Gestion des clients</h1>
+        <button onClick={() => setShowModal(true)} className="flex items-center rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+          <Plus className="mr-2 h-4 w-4" />
+          Ajouter un client
+        </button>
+      </div>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Rechercher..."
+          className="w-full rounded border px-3 py-1"
+        />
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {filterTags.map(tag => (
+          <button
+            key={tag}
+            onClick={() => setFilter(tag)}
+            className={`rounded-full px-3 py-1 text-sm shadow ${filter === tag ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+          >
+            {tag}
+          </button>
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {filtered.map(client => (
+          <ClientCard
+            key={client.id}
+            client={client}
+            onRefresh={() => alert(`Client actualisé : ${client.lastName}`)}
+            onEdit={() => alert(`Modifier client : ${client.lastName}`)}
+            onDelete={() => handleDelete(client.id)}
+          />
+        ))}
+      </div>
+      {filtered.length === 0 && (
+        <p className="mt-4 text-center text-gray-500">Aucun client pour le moment</p>
+      )}
+      <AddClientModal isOpen={showModal} onAdd={addClient} onClose={() => setShowModal(false)} />
+      <Toast message={toast} onClose={() => setToast(null)} />
+    </div>
+  );
 }

--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -3,6 +3,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { useEffect, useState } from 'react';
 import { useProjects, Task, DocumentFile, Project } from '../../components/ProjectsProvider';
+import { initialClients } from '../../lib/data/clients';
 
 interface FormValues {
   name: string;
@@ -125,8 +126,9 @@ export default function NewProjectPage() {
             ) : (
               <select {...register('client', { required: true })} className="w-full rounded border px-3 py-2">
                 <option value="">-- Sélectionner --</option>
-                <option value="Client A">Client A</option>
-                <option value="Client B">Client B</option>
+                {initialClients.map((c) => (
+                  <option key={c.id} value={`${c.firstName} ${c.lastName}`}>{`${c.firstName} ${c.lastName}`}</option>
+                ))}
               </select>
             )}
             {errors.client && <p className="text-sm text-red-600">Ce champ est requis</p>}

--- a/components/AddClientModal.tsx
+++ b/components/AddClientModal.tsx
@@ -1,0 +1,105 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { Client } from '../lib/data/clients';
+import { X } from 'lucide-react';
+
+interface AddClientModalProps {
+  isOpen: boolean;
+  onAdd: (client: Client) => void;
+  onClose: () => void;
+}
+
+interface FormValues {
+  firstName: string;
+  lastName: string;
+  company?: string;
+  email: string;
+  phone: string;
+  address: string;
+  status: 'Client' | 'Prospect';
+  tags: string;
+}
+
+export default function AddClientModal({ isOpen, onAdd, onClose }: AddClientModalProps) {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
+    defaultValues: { status: 'Client' }
+  });
+
+  if (!isOpen) return null;
+
+  const onSubmit = (data: FormValues) => {
+    const now = new Date();
+    const dateAdded = `${now.getDate().toString().padStart(2, '0')}/${
+      (now.getMonth() + 1).toString().padStart(2, '0')}/${now.getFullYear()}`;
+    onAdd({
+      id: Date.now().toString(),
+      firstName: data.firstName,
+      lastName: data.lastName,
+      company: data.company,
+      email: data.email,
+      phone: data.phone,
+      address: data.address,
+      status: data.status,
+      tags: data.tags ? data.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+      dateAdded,
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded bg-white p-6 shadow-lg dark:bg-gray-800 dark:text-gray-100">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-semibold">Ajouter un client</h2>
+          <button onClick={onClose}><X size={20} /></button>
+        </div>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Prénom</label>
+            <input className="w-full rounded border px-3 py-2" {...register('firstName', { required: true })} />
+            {errors.firstName && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Nom</label>
+            <input className="w-full rounded border px-3 py-2" {...register('lastName', { required: true })} />
+            {errors.lastName && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Entreprise</label>
+            <input className="w-full rounded border px-3 py-2" {...register('company')} />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Adresse email</label>
+            <input type="email" className="w-full rounded border px-3 py-2" {...register('email', { required: true })} />
+            {errors.email && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Téléphone</label>
+            <input className="w-full rounded border px-3 py-2" {...register('phone', { required: true })} />
+            {errors.phone && <p className="text-sm text-red-600">Ce champ est requis</p>}
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Adresse postale</label>
+            <input className="w-full rounded border px-3 py-2" {...register('address')} />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Statut</label>
+            <select className="w-full rounded border px-3 py-2" {...register('status')}>
+              <option value="Client">Client</option>
+              <option value="Prospect">Prospect</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Tags (séparés par des virgules)</label>
+            <input className="w-full rounded border px-3 py-2" {...register('tags')} placeholder="mariage, corporate" />
+          </div>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" onClick={onClose} className="rounded border px-4 py-1 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700">Annuler</button>
+            <button type="submit" className="rounded bg-blue-600 px-4 py-1 text-white hover:bg-blue-700">Ajouter</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/ClientCard.tsx
+++ b/components/ClientCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { Client } from '../lib/data/clients';
+import { RefreshCw, Pencil, Trash2 } from 'lucide-react';
+
+interface ClientCardProps {
+  client: Client;
+  onRefresh: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export default function ClientCard({ client, onRefresh, onEdit, onDelete }: ClientCardProps) {
+  const initials = `${client.firstName.charAt(0)}${client.lastName.charAt(0)}`;
+
+  return (
+    <div className="rounded border bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-center space-x-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-lg font-bold text-white">
+          {initials}
+        </div>
+        <div className="flex-1">
+          <p className="font-semibold">{client.firstName} {client.lastName}</p>
+          {client.company && <p className="text-sm text-gray-500">{client.company}</p>}
+        </div>
+        <span className={`rounded px-2 py-1 text-xs ${client.status === 'Client' ? 'bg-green-200 text-green-800' : 'bg-orange-200 text-orange-800'}`}>{client.status}</span>
+      </div>
+      <div className="mt-2 space-y-1 text-sm">
+        <a href={`mailto:${client.email}`} className="block text-blue-600 underline">{client.email}</a>
+        <p>{client.phone}</p>
+        <p>{client.address}</p>
+        <p className="text-xs text-gray-500">Ajouté le {client.dateAdded}</p>
+        <div className="flex flex-wrap gap-1 pt-1">
+          {client.tags.map(tag => (
+            <span key={tag} className="rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700">{tag}</span>
+          ))}
+        </div>
+      </div>
+      <div className="mt-3 flex justify-end space-x-2 text-sm">
+        <button onClick={onRefresh} className="rounded bg-gray-100 p-1 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"><RefreshCw size={16} /></button>
+        <button onClick={onEdit} className="rounded bg-gray-100 p-1 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"><Pencil size={16} /></button>
+        <button onClick={onDelete} className="rounded bg-red-500 p-1 text-white hover:bg-red-600"><Trash2 size={16} /></button>
+      </div>
+    </div>
+  );
+}

--- a/lib/data/clients.ts
+++ b/lib/data/clients.ts
@@ -1,0 +1,51 @@
+export interface Client {
+  id: string;
+  firstName: string;
+  lastName: string;
+  company?: string;
+  email: string;
+  phone: string;
+  address: string;
+  status: 'Client' | 'Prospect';
+  tags: string[];
+  dateAdded: string; // format DD/MM/YYYY
+}
+
+export const initialClients: Client[] = [
+  {
+    id: '1',
+    firstName: 'Sarah',
+    lastName: 'Martin',
+    company: 'Wedding Corp',
+    email: 'sarah.martin@example.com',
+    phone: '0601020304',
+    address: '12 rue des Fleurs, Paris',
+    status: 'Client',
+    tags: ['mariage', 'client-fidele'],
+    dateAdded: '01/03/2024',
+  },
+  {
+    id: '2',
+    firstName: 'Marc',
+    lastName: 'Dubois',
+    company: 'StartupX',
+    email: 'marc.dubois@example.com',
+    phone: '0605060708',
+    address: '5 avenue Victor Hugo, Lyon',
+    status: 'Prospect',
+    tags: ['startup', 'corporate'],
+    dateAdded: '15/03/2024',
+  },
+  {
+    id: '3',
+    firstName: 'Julie',
+    lastName: 'Rousseau',
+    company: 'E-Shop',
+    email: 'julie.rousseau@example.com',
+    phone: '0611223344',
+    address: '20 boulevard Alsace, Marseille',
+    status: 'Client',
+    tags: ['e-commerce'],
+    dateAdded: '20/03/2024',
+  },
+];


### PR DESCRIPTION
## Summary
- add `Client` data and example clients
- create `AddClientModal` to add a client
- create `ClientCard` for client display
- implement new `/clients` page with search, filters and modal
- expose client list in new project form

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685593dddc008329b44ed6fd6593fb65