### PR TITLE
Fix Next.js metadata export with client layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,10 +2,6 @@ import '../styles/globals.css';
 import Link from 'next/link';
 import Image from 'next/image';
 
-export const metadata = {
-  title: 'BKR STUDIO APP',
-};
-
 import { ReactNode } from 'react';
 import { ProjectsProvider } from '../components/ProjectsProvider';
 

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,0 +1,5 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'BKR STUDIO APP',
+};


### PR DESCRIPTION
## Summary
- move app metadata to dedicated server file
- clean up layout import section

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a59f9a9c88329970caa385ea7516d