### PR TITLE
Add sidebar component with Shadcn structure

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,21 @@
 import '../styles/globals.css';
 import Link from 'next/link';
 import Image from 'next/image';
+import { ChevronDown } from 'lucide-react';
+
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from '@/components/ui/sidebar';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
 
 import { ReactNode } from 'react';
 import { ProjectsProvider } from '../components/ProjectsProvider';
@@ -9,19 +24,61 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr" className="dark">
       <body className="flex min-h-screen bg-gray-900 text-gray-100 dark:bg-gray-900 dark:text-gray-100">
-        <aside className="w-60 flex-col bg-white dark:bg-gray-800 shadow-md">
-          <div className="flex items-center space-x-2 p-6 text-2xl font-bold">
-            <Image src="/logo.svg" width={32} height={32} alt="logo" />
-            <span>BKR STUDIO APP</span>
-          </div>
-          <nav className="mt-2 flex flex-col space-y-2 flex-1">
-            <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/">Tableau de bord</Link>
-            <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/projects">Projets</Link>
-            <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/clients">Clients</Link>
-            <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/organisation">Organisation</Link>
-            <Link className="px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/ressources">Ressources</Link>
-          </nav>
-        </aside>
+        <Sidebar>
+          <SidebarHeader>
+            <div className="flex items-center space-x-2 text-2xl font-bold">
+              <Image src="/logo.svg" width={32} height={32} alt="logo" />
+              <span>BKR STUDIO APP</span>
+            </div>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <SidebarMenuButton>
+                      Select Workspace
+                      <ChevronDown className="ml-auto" />
+                    </SidebarMenuButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
+                    <DropdownMenuItem>
+                      <span>Acme Inc</span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <span>Acme Corp.</span>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarHeader>
+          <SidebarMenu className="mt-2 flex-1">
+            <SidebarMenuItem>
+              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/">
+                Tableau de bord
+              </Link>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/projects">
+                Projets
+              </Link>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/clients">
+                Clients
+              </Link>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/organisation">
+                Organisation
+              </Link>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/ressources">
+                Ressources
+              </Link>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </Sidebar>
         <ProjectsProvider>
           <main className="flex-1">{children}</main>
         </ProjectsProvider>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+
+import { cn } from '../lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+
+import { cn } from '../lib/utils'
+
+const Sidebar = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex flex-col w-60 bg-white dark:bg-gray-800 shadow-md', className)}
+    {...props}
+  />
+))
+Sidebar.displayName = 'Sidebar'
+
+const SidebarHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('border-b p-4', className)} {...props} />
+))
+SidebarHeader.displayName = 'SidebarHeader'
+
+const SidebarMenu = React.forwardRef<
+  HTMLUListElement,
+  React.HTMLAttributes<HTMLUListElement>
+>(({ className, ...props }, ref) => (
+  <ul ref={ref} className={cn('px-2 py-4 space-y-1', className)} {...props} />
+))
+SidebarMenu.displayName = 'SidebarMenu'
+
+const SidebarMenuItem = React.forwardRef<
+  HTMLLIElement,
+  React.HTMLAttributes<HTMLLIElement>
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn('list-none', className)} {...props} />
+))
+SidebarMenuItem.displayName = 'SidebarMenuItem'
+
+const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ className, ...props }, ref) => (
+  <button
+    ref={ref}
+    className={cn(
+      'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700',
+      className
+    )}
+    {...props}
+  />
+))
+SidebarMenuButton.displayName = 'SidebarMenuButton'
+
+export { Sidebar, SidebarHeader, SidebarMenu, SidebarMenuItem, SidebarMenuButton }


### PR DESCRIPTION
## Summary
- add `Sidebar` and dropdown menu UI components
- replace old sidebar markup in layout with new Sidebar

## Testing
- `npx shadcn@latest add sidebar` *(fails: 403 Forbidden)*
- `npx shadcn@latest add dropdown-menu` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails with TS errors)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a785183688329be3a00c765c8d934