### PR TITLE
Improve client editing and card UI

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,10 +1,12 @@
 'use client';
-import { useState, useEffect } from 'react';
-import AddClientModal from '../../components/AddClientModal';
-import ClientCard from '../../components/ClientCard';
-import Toast from '../../components/Toast';
-import { initialClients, Client } from '../../lib/data/clients';
-import { Plus } from 'lucide-react';
+import { useState, useEffect } from 'react'
+import AddClientModal from '../../components/AddClientModal'
+import ClientCard from '../../components/ClientCard'
+import Toast from '../../components/Toast'
+import { initialClients, Client } from '../../lib/data/clients'
+import { Plus } from 'lucide-react'
+import { Input } from '../../components/ui/input'
+import { Button } from '../../components/ui/button'
 
 const filterTags = ['Tous', 'Prospect', 'Client', 'mariage', 'client-fidele', 'e-commerce', 'corporate', 'startup'];
 
@@ -25,6 +27,7 @@ export default function ClientsPage() {
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState('Tous');
   const [showModal, setShowModal] = useState(false);
+  const [editingClient, setEditingClient] = useState<Client | null>(null);
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
@@ -38,10 +41,20 @@ export default function ClientsPage() {
     setToast('Client ajouté avec succès');
   };
 
+  const updateClient = (client: Client) => {
+    setClients(clients.map(c => (c.id === client.id ? client : c)));
+    setToast('Client modifié avec succès');
+  };
+
   const handleDelete = (id: string) => {
     if (confirm('Supprimer client ?')) {
       setClients(clients.filter(c => c.id !== id));
     }
+  };
+
+  const handleEdit = (client: Client) => {
+    setEditingClient(client);
+    setShowModal(true);
   };
 
   const filtered = clients.filter(c => {
@@ -59,28 +72,37 @@ export default function ClientsPage() {
     <div className="p-4">
       <div className="mb-6 flex flex-col items-center justify-between gap-4 sm:flex-row">
         <h1 className="text-center text-4xl font-bold">Gestion des clients</h1>
-        <button onClick={() => setShowModal(true)} className="flex items-center rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
-          <Plus className="mr-2 h-4 w-4" />
+        <Button
+          onClick={() => {
+            setEditingClient(null);
+            setShowModal(true);
+          }}
+          className="flex items-center gap-2"
+        >
+          <Plus className="h-4 w-4" />
           Ajouter un client
-        </button>
+        </Button>
       </div>
       <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-        <input
+        <Input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Rechercher..."
-          className="w-full rounded border px-3 py-1"
+          className="w-full sm:max-w-xs"
         />
       </div>
       <div className="mb-4 flex flex-wrap gap-2">
         {filterTags.map(tag => (
-          <button
+          <Button
             key={tag}
+            type="button"
+            size="sm"
+            variant={filter === tag ? 'default' : 'outline'}
+            className="rounded-full"
             onClick={() => setFilter(tag)}
-            className={`rounded-full px-3 py-1 text-sm shadow ${filter === tag ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
           >
             {tag}
-          </button>
+          </Button>
         ))}
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -88,8 +110,7 @@ export default function ClientsPage() {
           <ClientCard
             key={client.id}
             client={client}
-            onRefresh={() => alert(`Client actualisé : ${client.lastName}`)}
-            onEdit={() => alert(`Modifier client : ${client.lastName}`)}
+            onEdit={() => handleEdit(client)}
             onDelete={() => handleDelete(client.id)}
           />
         ))}
@@ -97,7 +118,16 @@ export default function ClientsPage() {
       {filtered.length === 0 && (
         <p className="mt-4 text-center text-gray-500">Aucun client pour le moment</p>
       )}
-      <AddClientModal isOpen={showModal} onAdd={addClient} onClose={() => setShowModal(false)} />
+      <AddClientModal
+        isOpen={showModal}
+        client={editingClient ?? undefined}
+        onAdd={addClient}
+        onUpdate={updateClient}
+        onClose={() => {
+          setShowModal(false);
+          setEditingClient(null);
+        }}
+      />
       <Toast message={toast} onClose={() => setToast(null)} />
     </div>
   );

--- a/components/ClientCard.tsx
+++ b/components/ClientCard.tsx
@@ -1,45 +1,83 @@
 'use client';
-import { Client } from '../lib/data/clients';
-import { RefreshCw, Pencil, Trash2 } from 'lucide-react';
+import { Client } from '../lib/data/clients'
+import { Pencil, Trash2 } from 'lucide-react'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './ui/card'
+import { Button } from './ui/button'
 
 interface ClientCardProps {
   client: Client;
-  onRefresh: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }
 
-export default function ClientCard({ client, onRefresh, onEdit, onDelete }: ClientCardProps) {
+export default function ClientCard({ client, onEdit, onDelete }: ClientCardProps) {
   const initials = `${client.firstName.charAt(0)}${client.lastName.charAt(0)}`;
 
   return (
-    <div className="rounded border bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800">
-      <div className="flex items-center space-x-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-lg font-bold text-white">
+    <Card className="transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
+      <CardHeader className="flex flex-row items-center gap-3 pb-2">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground text-lg font-bold">
           {initials}
         </div>
         <div className="flex-1">
-          <p className="font-semibold">{client.firstName} {client.lastName}</p>
-          {client.company && <p className="text-sm text-gray-500">{client.company}</p>}
+          <CardTitle className="text-base font-semibold">
+            {client.firstName} {client.lastName}
+          </CardTitle>
+          {client.company && (
+            <p className="text-sm text-muted-foreground">{client.company}</p>
+          )}
         </div>
-        <span className={`rounded px-2 py-1 text-xs ${client.status === 'Client' ? 'bg-green-200 text-green-800' : 'bg-orange-200 text-orange-800'}`}>{client.status}</span>
-      </div>
-      <div className="mt-2 space-y-1 text-sm">
-        <a href={`mailto:${client.email}`} className="block text-blue-600 underline">{client.email}</a>
-        <p>{client.phone}</p>
-        <p>{client.address}</p>
-        <p className="text-xs text-gray-500">Ajouté le {client.dateAdded}</p>
-        <div className="flex flex-wrap gap-1 pt-1">
-          {client.tags.map(tag => (
-            <span key={tag} className="rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700">{tag}</span>
-          ))}
-        </div>
-      </div>
-      <div className="mt-3 flex justify-end space-x-2 text-sm">
-        <button onClick={onRefresh} className="rounded bg-gray-100 p-1 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"><RefreshCw size={16} /></button>
-        <button onClick={onEdit} className="rounded bg-gray-100 p-1 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"><Pencil size={16} /></button>
-        <button onClick={onDelete} className="rounded bg-red-500 p-1 text-white hover:bg-red-600"><Trash2 size={16} /></button>
-      </div>
-    </div>
-  );
+        <span
+          className={`rounded px-2 py-1 text-xs ${client.status === 'Client' ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}
+        >
+          {client.status}
+        </span>
+      </CardHeader>
+      <CardContent className="space-y-1 text-sm">
+        {client.email && (
+          <a
+            href={`mailto:${client.email}`}
+            className="block break-words text-primary underline"
+          >
+            {client.email}
+          </a>
+        )}
+        {client.phone && <p>{client.phone}</p>}
+        {client.address && <p>{client.address}</p>}
+        <p className="text-xs text-muted-foreground">Ajouté le {client.dateAdded}</p>
+        {client.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 pt-1">
+            {client.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="justify-end space-x-2 pt-2">
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          onClick={onEdit}
+          aria-label="Modifier"
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="destructive"
+          onClick={onDelete}
+          aria-label="Supprimer"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </CardFooter>
+    </Card>
+  )
 }


### PR DESCRIPTION
## Summary
- allow AddClientModal to edit existing clients
- polish ClientCard hover effect and remove refresh button
- open edit form with pre-filled data from Clients page

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b09ac02fc8329bef28c19b147ab65