### PR TITLE
Improve dark theme styles

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,80 +1,65 @@
+'use client';
 import '../styles/globals.css';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ChevronDown } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 import {
   Sidebar,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
-  SidebarMenuButton,
 } from '@/components/ui/sidebar';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/dropdown-menu';
 
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { ProjectsProvider } from '../components/ProjectsProvider';
 import { WebsitesProvider } from '../components/WebsitesProvider';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+
   return (
     <html lang="fr" className="dark">
       <body className="flex min-h-screen bg-gray-900 text-gray-100 dark:bg-gray-900 dark:text-gray-100">
-        <Sidebar>
-          <SidebarHeader>
-            <div className="flex items-center space-x-2 text-2xl font-bold">
-              <Image src="/logo.svg" width={32} height={32} alt="logo" />
-              <span>BKR STUDIO APP</span>
-            </div>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <SidebarMenuButton>
-                      Select Workspace
-                      <ChevronDown className="ml-auto" />
-                    </SidebarMenuButton>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
-                    <DropdownMenuItem>
-                      <span>Acme Inc</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem>
-                      <span>Acme Corp.</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </SidebarMenuItem>
-            </SidebarMenu>
+        <Sidebar collapsed={collapsed}>
+          <SidebarHeader className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setCollapsed(!collapsed)}
+              className="rounded p-1 hover:bg-gray-700"
+            >
+              {collapsed ? <ChevronRight className="h-5 w-5" /> : <ChevronLeft className="h-5 w-5" />}
+            </button>
+            {!collapsed && (
+              <div className="flex items-center space-x-2 text-2xl font-bold">
+                <Image src="/logo.svg" width={32} height={32} alt="logo" />
+                <span>BKR STUDIO APP</span>
+              </div>
+            )}
           </SidebarHeader>
           <SidebarMenu className="mt-2 flex-1">
             <SidebarMenuItem>
-              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/">
+              <Link className="block px-6 py-2 text-white hover:bg-gray-700" href="/">
                 Tableau de bord
               </Link>
             </SidebarMenuItem>
             <SidebarMenuItem>
-              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/projects">
+              <Link className="block px-6 py-2 text-white hover:bg-gray-700" href="/projects">
                 Projets
               </Link>
             </SidebarMenuItem>
             <SidebarMenuItem>
-              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/clients">
+              <Link className="block px-6 py-2 text-white hover:bg-gray-700" href="/clients">
                 Clients
               </Link>
             </SidebarMenuItem>
             <SidebarMenuItem>
-              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/organisation">
+              <Link className="block px-6 py-2 text-white hover:bg-gray-700" href="/organisation">
                 Organisation
               </Link>
             </SidebarMenuItem>
             <SidebarMenuItem>
-              <Link className="block px-6 py-2 hover:bg-gray-100 dark:hover:bg-gray-700" href="/ressources">
+              <Link className="block px-6 py-2 text-white hover:bg-gray-700" href="/ressources">
                 Ressources
               </Link>
             </SidebarMenuItem>

--- a/app/organisation/page.tsx
+++ b/app/organisation/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useProjects } from '../../components/ProjectsProvider';
 import Toast from '../../components/Toast';
 import { Plus, X, Pencil, Trash2 } from 'lucide-react';
+import { Input } from '../../components/ui/input';
 
 interface Task {
   id: number;
@@ -126,7 +127,7 @@ export default function OrganisationPage() {
               <button
                 key={status}
                 onClick={() => setTaskFilter(status)}
-                className={`rounded px-3 py-1 text-sm transition-colors ${taskFilter === status ? 'bg-black text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+                className={`rounded-md px-3 py-1 text-sm transition-colors ${taskFilter === status ? 'bg-black text-white' : 'bg-white text-black border border-gray-300'}`}
               >
                 {status}
               </button>
@@ -134,7 +135,7 @@ export default function OrganisationPage() {
             <select
               value={projectFilter}
               onChange={e => setProjectFilter(e.target.value)}
-              className="rounded border px-2 py-1 text-sm"
+              className="rounded-md border-gray-300 bg-white px-2 py-1 text-sm text-black shadow-sm"
             >
               <option value="Tous">Tous les projets</option>
               {projects.map(p => (
@@ -189,11 +190,11 @@ export default function OrganisationPage() {
         <header className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-xl font-semibold text-gray-900">Notes</h2>
           <div className="flex flex-wrap items-center gap-2">
-            <input
+            <Input
               value={noteSearch}
               onChange={e => setNoteSearch(e.target.value)}
               placeholder="Rechercher dans les notes..."
-              className="rounded border px-3 py-1 text-sm"
+              className="rounded-md border-gray-300 bg-white text-black px-3 py-1 text-sm shadow-sm"
             />
             {['Toutes', ...allTags].map(tag => (
               <button

--- a/app/ressources/page.tsx
+++ b/app/ressources/page.tsx
@@ -45,7 +45,7 @@ export default function RessourcesPage() {
 
   return (
     <div className="space-y-8 p-6">
-      <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-md">
+      <section className="space-y-4 rounded-xl border border-gray-200 bg-gray-100 text-black p-4 shadow-md">
         <header className="flex items-center justify-between">
           <h2 className="flex items-center text-xl font-semibold text-gray-900">
             <FileText className="mr-2 h-5 w-5" /> Documents
@@ -61,7 +61,7 @@ export default function RessourcesPage() {
           {documents.map(doc => (
             <div
               key={doc.id}
-              className="group relative rounded-xl border border-gray-200 bg-white p-4 shadow-md transition-transform hover:scale-105"
+              className="group relative rounded-xl border border-gray-200 bg-gray-100 text-black p-4 shadow-md transition-transform hover:scale-105"
             >
               {doc.priority && (
                 <Star className="absolute right-2 top-2 h-4 w-4 text-yellow-500" />
@@ -89,7 +89,7 @@ export default function RessourcesPage() {
         </div>
       </section>
 
-      <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-md">
+      <section className="space-y-4 rounded-xl border border-gray-200 bg-gray-100 text-black p-4 shadow-md">
         <header className="flex items-center justify-between">
           <h2 className="flex items-center text-xl font-semibold text-gray-900">
             <Globe className="mr-2 h-5 w-5" /> Sites Web
@@ -105,7 +105,7 @@ export default function RessourcesPage() {
           {sites.map(site => (
             <div
               key={site.id}
-              className="rounded-xl border border-gray-200 bg-white p-4 shadow-md transition-transform hover:scale-105"
+              className="rounded-xl border border-gray-200 bg-gray-100 text-black p-4 shadow-md transition-transform hover:scale-105"
             >
               <h3 className="font-bold">{site.name}</h3>
               <p className="text-sm text-gray-600">{site.category}</p>

--- a/components/ProjectList.tsx
+++ b/components/ProjectList.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import { Input } from './ui/input';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ProjectCard from './ProjectCard';
@@ -93,18 +94,18 @@ export default function ProjectList() {
         </Link>
       </div>
       <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-        <input
+        <Input
           aria-label="Rechercher"
           value={search}
           onChange={e => setSearch(e.target.value)}
-          className="w-full rounded border px-3 py-1"
+          className="w-full rounded-md border-gray-300 bg-white text-black shadow-sm"
           placeholder="Rechercher..."
         />
         <select
           aria-label="Trier"
           value={sort}
           onChange={e => setSort(e.target.value as any)}
-          className="rounded border px-3 py-1"
+          className="rounded-md border-gray-300 bg-white px-3 py-1 text-black shadow-sm"
         >
           <option value="date-desc">Date ↓</option>
           <option value="date-asc">Date ↑</option>
@@ -116,7 +117,7 @@ export default function ProjectList() {
           aria-label="Paiement"
           value={filterPayment}
           onChange={e => setFilterPayment(e.target.value as any)}
-          className="rounded border px-3 py-1"
+          className="rounded-md border-gray-300 bg-white px-3 py-1 text-black shadow-sm"
         >
           <option value="Tous">Tous</option>
           <option value="Payé">Payé</option>
@@ -126,7 +127,7 @@ export default function ProjectList() {
         <button
           aria-label="Vue Kanban"
           onClick={() => setView(view === 'grid' ? 'kanban' : 'grid')}
-          className="rounded border px-3 py-1"
+          className="rounded-md border-gray-300 bg-white px-3 py-1 text-black shadow-sm"
         >
           {view === 'grid' ? 'Kanban' : 'Grille'}
         </button>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -2,16 +2,22 @@ import * as React from 'react'
 
 import { cn } from '../lib/utils'
 
-const Sidebar = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn('flex flex-col w-60 bg-white dark:bg-gray-800 shadow-md', className)}
-    {...props}
-  />
-))
+interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
+  collapsed?: boolean
+}
+
+const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
+  ({ className, collapsed, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        `flex flex-col ${collapsed ? 'w-16' : 'w-60'} bg-[#0f172a] text-white shadow-md transition-all duration-300`,
+        className
+      )}
+      {...props}
+    />
+  )
+)
 Sidebar.displayName = 'Sidebar'
 
 const SidebarHeader = React.forwardRef<


### PR DESCRIPTION
## Summary
- restyle the sidebar and add collapse toggle
- use shadcn `Input` in project and organisation pages
- adjust colors for filters and search boxes
- fix resource cards with readable dark theme colors

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c29f4f6f48329899a6137019715b9