### PR TITLE
Add agenda and todo lists

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -41,6 +41,8 @@ import { useWebsites, Website } from '@/components/WebsitesProvider'
 import Toast from '@/components/Toast'
 import AnnualObjectiveCard from '@/components/AnnualObjectiveCard'
 import { cn } from '@/components/lib/utils'
+import TodoList from '@/components/TodoList'
+import Agenda from '@/components/Agenda'
 
 interface Task {
   id: number
@@ -51,6 +53,12 @@ interface Task {
   dueDate: string
   priority: 'Urgente' | 'Normale' | 'Faible'
   status: 'En cours' | 'Terminée'
+}
+
+interface Note {
+  id: number
+  title: string
+  createdAt: string
 }
 
 const statusColors: Record<Status, string> = {
@@ -66,6 +74,7 @@ export default function DashboardPage() {
   const { projects, deleteProject } = useProjects()
   const { websites, addWebsite, updateWebsite, deleteWebsite } = useWebsites()
   const [tasks, setTasks] = useState<Task[]>([])
+  const [notes, setNotes] = useState<Note[]>([])
   const [stepFilter, setStepFilter] = useState<Status | 'Tous'>('Tous')
   const [showSiteModal, setShowSiteModal] = useState(false)
   const [editingSite, setEditingSite] = useState<Website | null>(null)
@@ -77,6 +86,19 @@ export default function DashboardPage() {
       if (stored) {
         try {
           setTasks(JSON.parse(stored) as Task[])
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('notes')
+      if (stored) {
+        try {
+          setNotes(JSON.parse(stored) as Note[])
         } catch {
           /* ignore */
         }
@@ -150,6 +172,13 @@ export default function DashboardPage() {
   return (
     <div className="space-y-8 p-6">
       <h1 className="text-2xl font-bold mb-6">Tableau de bord</h1>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <TodoList storageKey="todo1" defaultTitle="Tâches à effectuer" />
+        <TodoList storageKey="todo2" defaultTitle="Idées" />
+      </div>
+      <div className="mt-4">
+        <Agenda projects={projects} tasks={tasks} notes={notes} />
+      </div>
       <section className="space-y-2">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">Sites favoris</h2>

--- a/components/Agenda.tsx
+++ b/components/Agenda.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { useMemo } from 'react'
+import { Calendar, dateFnsLocalizer, Event } from 'react-big-calendar'
+import format from 'date-fns/format'
+import parse from 'date-fns/parse'
+import startOfWeek from 'date-fns/startOfWeek'
+import getDay from 'date-fns/getDay'
+import fr from 'date-fns/locale/fr'
+import 'react-big-calendar/lib/css/react-big-calendar.css'
+import { useRouter } from 'next/navigation'
+import { Project } from './ProjectsProvider'
+
+interface Task { id: number; title: string; dueDate: string }
+interface Note { id: number; title: string; createdAt: string }
+
+interface AgendaProps {
+  projects: Project[]
+  tasks: Task[]
+  notes: Note[]
+}
+
+const locales = {
+  fr
+}
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales
+})
+
+export default function Agenda({ projects, tasks, notes }: AgendaProps) {
+  const router = useRouter()
+
+  const events = useMemo(() => {
+    const ev: Event[] = []
+    projects.forEach(p => {
+      ev.push({
+        title: `Début ${p.name}`,
+        start: new Date(p.startDate),
+        end: new Date(p.startDate),
+        resource: { type: 'project', id: p.id }
+      })
+    })
+    tasks.forEach(t => {
+      if (t.dueDate)
+        ev.push({
+          title: t.title,
+          start: new Date(t.dueDate),
+          end: new Date(t.dueDate),
+          resource: { type: 'task', id: t.id }
+        })
+    })
+    notes.forEach(n => {
+      ev.push({
+        title: n.title,
+        start: new Date(n.createdAt),
+        end: new Date(n.createdAt),
+        resource: { type: 'note', id: n.id }
+      })
+    })
+    return ev
+  }, [projects, tasks, notes])
+
+  const onSelect = (event: Event) => {
+    const { type, id } = (event.resource || {}) as any
+    if (type === 'project') router.push('/projects')
+    if (type === 'task') router.push('/tasks')
+    if (type === 'note') router.push('/notes')
+  }
+
+  return (
+    <div className="h-96 bg-white rounded-lg p-2">
+      <Calendar
+        localizer={localizer}
+        events={events}
+        startAccessor="start"
+        endAccessor="end"
+        style={{ height: '100%' }}
+        onSelectEvent={onSelect}
+      />
+    </div>
+  )
+}

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { Input } from './ui/input'
+import { Button } from './ui/button'
+import { Checkbox } from './ui/checkbox'
+import { Trash } from 'lucide-react'
+import { cn } from './lib/utils'
+
+interface Item {
+  id: number
+  text: string
+  done: boolean
+}
+
+interface TodoListProps {
+  storageKey: string
+  defaultTitle: string
+}
+
+export default function TodoList({ storageKey, defaultTitle }: TodoListProps) {
+  const [title, setTitle] = useState(defaultTitle)
+  const [items, setItems] = useState<Item[]>([])
+  const [input, setInput] = useState('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(storageKey)
+      if (stored) {
+        try {
+          const data = JSON.parse(stored) as { title: string; items: Item[] }
+          setTitle(data.title || defaultTitle)
+          setItems(data.items || [])
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }, [storageKey, defaultTitle])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, JSON.stringify({ title, items }))
+    }
+  }, [title, items, storageKey])
+
+  const addItem = () => {
+    const text = input.trim()
+    if (!text) return
+    setItems(prev => [...prev, { id: Date.now(), text, done: false }])
+    setInput('')
+  }
+
+  const toggle = (id: number) => {
+    setItems(prev => prev.map(it => (it.id === id ? { ...it, done: !it.done } : it)))
+  }
+
+  const remove = (id: number) => {
+    setItems(prev => prev.filter(it => it.id !== id))
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <Input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="font-semibold text-lg"
+        />
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.map(item => (
+          <div key={item.id} className="flex items-center space-x-2">
+            <Checkbox checked={item.done} onCheckedChange={() => toggle(item.id)} id={`cb-${storageKey}-${item.id}`} />
+            <label
+              htmlFor={`cb-${storageKey}-${item.id}`}
+              className={cn('flex-1 text-sm', item.done && 'line-through text-muted-foreground')}
+            >
+              {item.text}
+            </label>
+            <Button size="icon" variant="ghost" onClick={() => remove(item.id)}>
+              <Trash className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+        <div className="flex items-center space-x-2 pt-1">
+          <Input
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') addItem()
+            }}
+            placeholder="Ajouter..."
+          />
+          <Button size="icon" onClick={addItem}>
+            +
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { CheckIcon } from '@radix-ui/react-icons'
+import { cn } from '../lib/utils'
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <CheckIcon className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.14.1",
     "recharts": "^2.7.2",
+    "react-big-calendar": "^1.11.3",
+    "date-fns": "^3.6.0",
     "framer-motion": "^10.16.1",
     "shadcn-ui": "^0.1.0",
     "tailwind-merge": "^3.3.1",


### PR DESCRIPTION
## Summary
- create Checkbox component based on Radix
- add reusable TodoList component with local persistence
- add Agenda calendar using react-big-calendar
- enhance dashboard with two todo lists and agenda
- include new dependencies for calendar functionality

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb05acd9c832993fd00470c3c1c70