### PR TITLE
Replace Radix icons with Lucide

### DIFF
--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { CheckIcon } from '@radix-ui/react-icons'
+import { Check } from 'lucide-react'
 import { cn } from '../lib/utils'
 
 const Checkbox = React.forwardRef<
@@ -16,7 +16,7 @@ const Checkbox = React.forwardRef<
     {...props}
   >
     <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-      <CheckIcon className="h-4 w-4" />
+      <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))


### PR DESCRIPTION
## Summary
- replace Radix `CheckIcon` with Lucide `Check`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec08cc5ac8329a2d7229a74c91b20