### PR TITLE
feat: add ClientsProvider with Supabase

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ import { ReactNode, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { ProjectsProvider } from '../components/ProjectsProvider';
 import { WebsitesProvider } from '../components/WebsitesProvider';
+import { ClientsProvider } from '../lib/providers/ClientsProvider';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -127,9 +128,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           </SidebarMenu>
         </Sidebar>
         <ProjectsProvider>
-          <WebsitesProvider>
-            <main className="flex-1">{children}</main>
-          </WebsitesProvider>
+          <ClientsProvider>
+            <WebsitesProvider>
+              <main className="flex-1">{children}</main>
+            </WebsitesProvider>
+          </ClientsProvider>
         </ProjectsProvider>
       </body>
     </html>

--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 import { useProjects, Task, DocumentFile } from "../../components/ProjectsProvider";
 import { supabase } from "../../lib/supabaseClient";
-import { Client, initialClients } from "../../lib/data/clients";
+import { useClients, Client } from "@/lib/providers/ClientsProvider";
 import { Input } from "../../components/ui/input";
 import { DateInput } from "../../components/ui/date-input";
 import {
@@ -61,20 +61,8 @@ export default function NewProjectPage() {
   const [tasks, setTasks] = useState<Task[]>(project?.tasks ?? []);
   const [taskText, setTaskText] = useState("");
   const [documents, setDocuments] = useState<DocumentFile[]>(project?.documents ?? []);
+  const { clients } = useClients();
   const [manualClient, setManualClient] = useState(project ? false : true);
-  const [clients, setClients] = useState<Client[]>(() => {
-    if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("clients");
-      if (stored) {
-        try {
-          return JSON.parse(stored) as Client[];
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-    return initialClients;
-  });
 
   const [loading, setLoading] = useState(false);
   const [closing, setClosing] = useState(false);
@@ -236,7 +224,7 @@ export default function NewProjectPage() {
                     </SelectTrigger>
                     <SelectContent>
                       {clients.map((c) => (
-                        <SelectItem key={c.id} value={`${c.firstName} ${c.lastName}`}>{`${c.firstName} ${c.lastName}`}</SelectItem>
+                        <SelectItem key={c.id} value={`${c.first_name} ${c.last_name}`}>{`${c.first_name} ${c.last_name}`}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>

--- a/components/ClientCard.tsx
+++ b/components/ClientCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Client } from '../lib/data/clients'
+import { Client } from '@/lib/providers/ClientsProvider'
 import { Pencil, Trash2 } from 'lucide-react'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './ui/card'
 import { Button } from './ui/button'
@@ -13,8 +13,8 @@ interface ClientCardProps {
 }
 
 export default function ClientCard({ client, onEdit, onDelete }: ClientCardProps) {
-  const initials = `${client.firstName.charAt(0)}${client.lastName.charAt(0)}`
-  const bg = stringToHslColor(client.firstName + client.lastName)
+  const initials = `${client.first_name.charAt(0)}${client.last_name.charAt(0)}`
+  const bg = stringToHslColor(client.first_name + client.last_name)
 
   return (
     <Card className="mx-auto w-full max-w-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
@@ -27,7 +27,7 @@ export default function ClientCard({ client, onEdit, onDelete }: ClientCardProps
         </div>
         <div className="flex-1">
           <CardTitle className="text-lg font-semibold">
-            {client.firstName} {client.lastName}
+            {client.first_name} {client.last_name}
           </CardTitle>
           {client.company && (
             <p className="text-sm text-muted-foreground">{client.company}</p>
@@ -51,14 +51,20 @@ export default function ClientCard({ client, onEdit, onDelete }: ClientCardProps
         {client.phone && <p className="text-muted-foreground">{client.phone}</p>}
         {client.address && <p className="text-muted-foreground">{client.address}</p>}
         <div className="my-2 h-px bg-border" />
-        <p className="text-xs text-muted-foreground">Ajouté le {client.dateAdded}</p>
-        {client.tags.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Ajouté le {new Date(client.created_at).toLocaleDateString()}
+        </p>
+        {client.tags.split(',').filter(t => t.trim()).length > 0 && (
           <div className="flex flex-wrap gap-1 pt-1">
-            {client.tags.map((tag) => (
-              <Badge key={tag} className="animate-in fade-in-0 zoom-in-95" variant="secondary">
-                {tag}
-              </Badge>
-            ))}
+            {client.tags
+              .split(',')
+              .map(t => t.trim())
+              .filter(Boolean)
+              .map(tag => (
+                <Badge key={tag} className="animate-in fade-in-0 zoom-in-95" variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
           </div>
         )}
       </CardContent>

--- a/lib/providers/ClientsProvider.tsx
+++ b/lib/providers/ClientsProvider.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+
+export interface Client {
+  id: string
+  first_name: string
+  last_name: string
+  email: string
+  phone: string
+  company: string
+  address: string
+  status: string
+  tags: string
+  created_at: string
+}
+
+interface ClientsContextValue {
+  clients: Client[]
+  loading: boolean
+  addClient: (client: Omit<Client, 'id' | 'created_at'>) => Promise<void>
+}
+
+const ClientsContext = createContext<ClientsContextValue | undefined>(undefined)
+
+export function ClientsProvider({ children }: { children: ReactNode }) {
+  const [clients, setClients] = useState<Client[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchClients = async () => {
+      setLoading(true)
+      const { data, error } = await supabase.from('clients').select('*')
+      if (error) {
+        console.error('Error loading clients:', error)
+      } else if (data) {
+        setClients(data as Client[])
+      }
+      setLoading(false)
+    }
+
+    fetchClients()
+  }, [])
+
+  const addClient = async (client: Omit<Client, 'id' | 'created_at'>) => {
+    const { data, error } = await supabase
+      .from('clients')
+      .insert(client)
+      .select()
+      .single()
+    if (error) {
+      console.error('Error adding client:', error)
+      return
+    }
+    if (data) {
+      setClients((prev) => [...prev, data as Client])
+    }
+  }
+
+  return (
+    <ClientsContext.Provider value={{ clients, loading, addClient }}>
+      {children}
+    </ClientsContext.Provider>
+  )
+}
+
+export function useClients() {
+  const context = useContext(ClientsContext)
+  if (!context) {
+    throw new Error('useClients must be used within ClientsProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- add `ClientsProvider` to load and insert clients from Supabase
- adapt `AddClientModal` to use new Client type
- update `ClientCard` to show Supabase data
- refactor clients page to consume provider
- use provider in new project page
- wrap app with `ClientsProvider`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb28a607c8329b0668025b7e2c60b