### PR TITLE
Fix Supabase config

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,5 +1,3 @@
-console.log('SUPABASE_URL:', process.env.NEXT_PUBLIC_SUPABASE_URL);
-console.log('SUPABASE_ANON_KEY:', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "shadcn-ui": "^0.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@supabase/supabase-js": "^2.39.7"
   },
   "devDependencies": {
     "@types/node": "24.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"]
+      "@/lib/*": ["lib/*"],
+      "@/providers/*": ["providers/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- add TypeScript alias for the `providers` directory
- remove debug logging from the Supabase client
- include `@supabase/supabase-js` dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68606e42f5c08329a0057e16e0cedb06