### PR TITLE
Fix project edit form and calendar icon

### DIFF
--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -95,24 +95,30 @@ export default function NewProjectPage() {
   });
 
   useEffect(() => {
-    if (project) {
+    const current = editId
+      ? projects.find(p => p.id === Number(editId))
+      : duplicateId
+        ? projects.find(p => p.id === Number(duplicateId))
+        : undefined
+
+    if (current) {
       reset({
-        name: project.name,
-        client: project.client,
-        description: project.description,
-        startDate: project.startDate,
-        dueDate: project.endDate,
-        status: project.status as FormValues["status"],
-        type: project.type as FormValues["type"],
-        paymentStatus: project.paymentStatus,
-        budget: project.budget,
-        notes: project.notes,
-      });
-      setTasks(project.tasks);
-      setDocuments(project.documents);
-      setManualClient(false);
+        name: current.name,
+        client: current.client,
+        description: current.description,
+        startDate: current.startDate,
+        dueDate: current.endDate,
+        status: current.status as FormValues['status'],
+        type: current.type as FormValues['type'],
+        paymentStatus: current.paymentStatus,
+        budget: current.budget,
+        notes: current.notes,
+      })
+      setTasks(current.tasks)
+      setDocuments(current.documents)
+      setManualClient(false)
     }
-  }, [project, reset]);
+  }, [editId, duplicateId, projects, reset])
 
   const addTask = () => {
     if (!taskText.trim()) return;
@@ -190,7 +196,15 @@ export default function NewProjectPage() {
         }}
       >
         <Card className="mx-auto max-w-3xl backdrop-blur-md">
-        <CardHeader>
+        <CardHeader className="relative">
+          <button
+            type="button"
+            onClick={() => setClosing(true)}
+            aria-label="Fermer le formulaire"
+            className="absolute left-2 top-2 rounded p-1 text-gray-400 hover:bg-gray-700 hover:text-white"
+          >
+            ✖
+          </button>
           <CardTitle>{editId ? "Modifier le projet" : "Nouveau projet"}</CardTitle>
         </CardHeader>
         <CardContent>

--- a/components/ui/date-input.tsx
+++ b/components/ui/date-input.tsx
@@ -5,19 +5,34 @@ import { Input } from './input'
 
 export interface DateInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(({ className, ...props }, ref) => {
-  return (
-    <div className="relative">
-      <Input
-        ref={ref}
-        type="date"
-        className={cn('pl-8', className)}
-        {...props}
-      />
-      <CalendarIcon className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-    </div>
-  )
-})
+const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
+  ({ className, ...props }, ref) => {
+    const internalRef = React.useRef<HTMLInputElement>(null)
+    React.useImperativeHandle(ref, () => internalRef.current as HTMLInputElement)
+
+    const openPicker = () => {
+      internalRef.current?.showPicker?.()
+    }
+
+    return (
+      <div className="relative">
+        <Input
+          ref={internalRef}
+          type="date"
+          className={cn('pl-8', className)}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={openPicker}
+          className="absolute left-2 top-1/2 -translate-y-1/2 text-primary hover:text-primary/80"
+        >
+          <CalendarIcon className="h-4 w-4" />
+        </button>
+      </div>
+    )
+  }
+)
 DateInput.displayName = 'DateInput'
 
 export { DateInput }


### PR DESCRIPTION
## Summary
- pre-fill project form when editing
- add close button to project form
- improve date picker visibility and clickability

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b8642dc8329b098633e8057a2b3